### PR TITLE
Fix PHP error in Exception\Standard

### DIFF
--- a/lib/PaymentRails/Exception/Standard.php
+++ b/lib/PaymentRails/Exception/Standard.php
@@ -18,7 +18,7 @@ class Standard extends Exception
       $errors = json_decode($errorBody)->errors;
       $message = "";
       foreach ($errors as $e) {
-        $message = $message . ($e->field ? $e->field : $e->code) . ": " . $e->message . "\n";
+        $message = $message . ($e->field ?? $e->code) . ": " . $e->message . "\n";
       }
       $this->message = $message;
   }


### PR DESCRIPTION
Use null coalescing operator to check `field` property

When making a call to PaymentRails\Batch::payments (this endpoint: `https://api.paymentrails.com/v1/batches/:batch-id/payments`) if the response contains
an array of errors, the `field` property is missing from those error objects. 