### PR TITLE
Add footnote for Payment Rails => Trolley rebranding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
-# Payment Rails PHP Library
+# Payment Rails[^1] PHP Library
 
 [![Latest Stable Version](https://poser.pugx.org/paymentrails/php-sdk/v/stable.png)](https://packagist.org/packages/paymentrails/php-sdk)
 
 The Payment Rails PHP library provides integration access to the Payment Rails API.
 
+[^1]: [Payment Rails is now Trolley](https://www.trolley.com/payment-rails-is-now-trolley-series-a), we'll be updating our SDKs to support the new domain during the first half of 2022.
 
 ## Requirements
 


### PR DESCRIPTION
The plan is to update SKDs to support the new domain during the first half of 2022 (also noted in the README).