### PR TITLE
feat!: throw StandardException with a stringified error message

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 vendor
 composer.phar
 run.php
+.vscode

--- a/README.md
+++ b/README.md
@@ -74,3 +74,14 @@ try {
 ## Documentation for API Endpoints
 
 All URIs are available at http://docs.paymentrails.com/
+
+## Running SDK from Source  
+  1. Clone this repo.
+  2. Install dependencies by running `composer install` from the project root.
+  3. Access the SDK source code from your code by using `PaymentRails` namespace as per the path you put the SDK source code on.
+
+### Running the tests from SDK  
+To run the tests in the terminal, use the PHPUnit test suite from within the `tests` directory, like the following:  
+```
+$ ../vendor/bin/phpunit integration/RecipientTest.php
+```

--- a/lib/PaymentRails/BalanceGateway.php
+++ b/lib/PaymentRails/BalanceGateway.php
@@ -56,6 +56,8 @@ class BalanceGateway
             }, $response['balances']);
 
             return new ResourceCollection($response, $items, $pager);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }

--- a/lib/PaymentRails/BatchGateway.php
+++ b/lib/PaymentRails/BatchGateway.php
@@ -56,6 +56,8 @@ class BatchGateway
             }, $response['batches']);
 
             return new ResourceCollection($response, $items, $pager);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -82,6 +84,8 @@ class BatchGateway
         $response = $this->_http->post('/v1/batches', $copy);
         if ($response['ok']) {
             return Batch::factory($response['batch']);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -91,6 +95,8 @@ class BatchGateway
         $response = $this->_http->patch('/v1/batches/' . $batchId, $attrib);
         if ($response['ok']) {
             return true;
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -100,6 +106,8 @@ class BatchGateway
         $response = $this->_http->delete('/v1/batches/' . $batchId);
         if ($response['ok']) {
             return true;
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -109,6 +117,8 @@ class BatchGateway
         $response = $this->_http->get('/v1/batches/' . $batchId . '/summary');
         if ($response['ok']) {
             return BatchSummary::factory($response['batchSummary']);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -118,6 +128,8 @@ class BatchGateway
         $response = $this->_http->post('/v1/batches/' . $batchId . '/generate-quote');
         if ($response['ok']) {
             return true;
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -127,6 +139,8 @@ class BatchGateway
         $response = $this->_http->post('/v1/batches/' . $batchId . '/start-processing');
         if ($response['ok']) {
             return true;
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -136,6 +150,8 @@ class BatchGateway
         $response = $this->_http->post('/v1/batches/' . $batchId . '/payments', $payment);
         if ($response['ok']) {
             return Payment::factory($response['payment']);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -145,6 +161,8 @@ class BatchGateway
         $response = $this->_http->get('/v1/batches/' . $batchId . '/payments/' . $paymentId);
         if ($response['ok']) {
             return Payment::factory($response['payment']);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -154,6 +172,8 @@ class BatchGateway
         $response = $this->_http->patch('/v1/batches/' . $batchId . '/payments/' . $paymentId, $params);
         if ($response['ok']) {
             return true;
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -163,6 +183,8 @@ class BatchGateway
         $response = $this->_http->delete('/v1/batches/' . $batchId . '/payments/' . $paymentId);
         if ($response['ok']) {
             return true;
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -188,6 +210,8 @@ class BatchGateway
             }, $response['payments']);
 
             return new ResourceCollection($response, $items, $pager);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }

--- a/lib/PaymentRails/Exception/Standard.php
+++ b/lib/PaymentRails/Exception/Standard.php
@@ -15,13 +15,12 @@ class Standard extends Exception
 
   public function __construct($errorBody)
   {
-      $errors = json_decode($errorBody)->errors;
       $message = "";
-      foreach ($errors as $e) {
-        if (isset($e->field)) {
-          $message = $message . $e->field . " " . $e->code . ": " . $e->message . "\n";
+      foreach ($errorBody as $e) {
+        if (isset($e['field'])) {
+          $message = $message . $e['code'] . ": " . $e['message'] . " (field: '" . $e['field'] . "') \n";
         } else {
-          $message = $message . $e->code . ": " . $e->message . "\n";
+          $message = $message . $e['code'] . ": " . $e['message'] . "\n";
         }
       }
       $this->message = $message;

--- a/lib/PaymentRails/OfflinePaymentGateway.php
+++ b/lib/PaymentRails/OfflinePaymentGateway.php
@@ -62,6 +62,8 @@ class OfflinePaymentGateway
             }, $response['offlinePayments']);
 
             return new ResourceCollection($response, $items, $pager);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -71,6 +73,8 @@ class OfflinePaymentGateway
       $response = $this->_http->post('/v1/recipients/' . $recipientId . '/offlinePayments', $offlinePaymentBody);
       if ($response['ok']) {
           return OfflinePayment::factory($response['offlinePayment']);
+      } else if ($response['errors']){
+        throw new Exception\Standard($response['errors']);
       } else {
           throw new Exception\DownForMaintenance();
       }
@@ -80,6 +84,8 @@ class OfflinePaymentGateway
       $response = $this->_http->patch('/v1/recipients/' . $recipientId . '/offlinePayments/' . $offlinePaymentId, $offlinePaymentBody);
       if ($response['ok']) {
           return true;
+      } else if ($response['errors']){
+        throw new Exception\Standard($response['errors']);
       } else {
           throw new Exception\DownForMaintenance();
       }
@@ -89,6 +95,8 @@ class OfflinePaymentGateway
       $response = $this->_http->delete('/v1/recipients/' . $recipientId . '/offlinePayments/' . $offlinePaymentId);
       if ($response['ok']) {
           return true;
+      } else if ($response['errors']){
+        throw new Exception\Standard($response['errors']);
       } else {
           throw new Exception\DownForMaintenance();
       }

--- a/lib/PaymentRails/PaymentGateway.php
+++ b/lib/PaymentRails/PaymentGateway.php
@@ -58,6 +58,8 @@ class PaymentGateway
             }, $response['payments']);
 
             return new ResourceCollection($response, $items, $pager);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }

--- a/lib/PaymentRails/RecipientAccountGateway.php
+++ b/lib/PaymentRails/RecipientAccountGateway.php
@@ -49,6 +49,8 @@ class RecipientAccountGateway
             return array_map(function ($item) {
                 return RecipientAccount::factory($item);
             }, $response['accounts']);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -62,6 +64,8 @@ class RecipientAccountGateway
 
         if ($response['ok']) {
             return RecipientAccount::factory($response['account']);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -71,6 +75,8 @@ class RecipientAccountGateway
         $response = $this->_http->post('/v1/recipients/' . $recipientId . '/accounts', $attrib);
         if ($response['ok']) {
             return RecipientAccount::factory($response['account']);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -80,6 +86,8 @@ class RecipientAccountGateway
         $response = $this->_http->patch('/v1/recipients/' . $recipientId . '/accounts/' . $accountId, $attrib);
         if ($response['ok']) {
             return Recipient::factory($response['account']);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -89,6 +97,8 @@ class RecipientAccountGateway
         $response = $this->_http->delete('/v1/recipients/' . $recipientId . '/accounts/' . $accountId);
         if ($response['ok']) {
             return true;
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }

--- a/lib/PaymentRails/RecipientGateway.php
+++ b/lib/PaymentRails/RecipientGateway.php
@@ -58,6 +58,8 @@ class RecipientGateway
             }, $response['recipients']);
 
             return new ResourceCollection($response, $items, $pager);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -71,6 +73,8 @@ class RecipientGateway
 
         if ($response['ok']) {
             return Recipient::factory($response['recipient']);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -80,6 +84,8 @@ class RecipientGateway
         $response = $this->_http->post('/v1/recipients', $attrib);
         if ($response['ok']) {
             return Recipient::factory($response['recipient']);
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }
@@ -89,6 +95,8 @@ class RecipientGateway
         $response = $this->_http->patch('/v1/recipients/' . $id, $attrib);
         if ($response['ok']) {
             return true;
+        } else if ($response['errors']){
+            throw new Exception\Standard($response['errors']);
         } else {
             throw new Exception\DownForMaintenance();
         }

--- a/tests/Setup.php
+++ b/tests/Setup.php
@@ -20,8 +20,8 @@ class Setup extends TestCase
     {
         Configuration::reset();
 
-        Configuration::environment('production');
-        Configuration::publicKey('ASC7AsydNKAKBB5BNEVFVZ0P');
-        Configuration::privateKey('4vapebxbpq26gmk7a2zdj837u0qn24ufynqnnjfq');
+        Configuration::environment('development');
+        Configuration::publicKey('integration_public_key');
+        Configuration::privateKey('integration_private_key');
     }
 }

--- a/tests/Setup.php
+++ b/tests/Setup.php
@@ -2,13 +2,14 @@
 namespace Test;
 
 // require_once __DIR__ . '/Helper.php';
+require_once '../vendor/autoload.php';
 
 date_default_timezone_set('UTC');
 
 use PaymentRails\Configuration;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class Setup extends PHPUnit_Framework_TestCase
+class Setup extends TestCase
 {
     public function __construct()
     {
@@ -19,8 +20,8 @@ class Setup extends PHPUnit_Framework_TestCase
     {
         Configuration::reset();
 
-        Configuration::environment('development');
-        Configuration::publicKey('integration_public_key');
-        Configuration::privateKey('integration_private_key');
+        Configuration::environment('production');
+        Configuration::publicKey('ASC7AsydNKAKBB5BNEVFVZ0P');
+        Configuration::privateKey('4vapebxbpq26gmk7a2zdj837u0qn24ufynqnnjfq');
     }
 }


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fixes #

Send a StandardException whenever the API returns an "errors" array response.
Earlier if the $response ["ok"] was false, the SDK would send a DownForMaintenance() exception, without specifying the API error even if the API sent back error messages.
Now, whatever error responses API returns in `$response["errors"]` are string-ified and sent as a message in StandardException, so developer know what went wrong.

### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [ ] I have added inline documentation to the code I modified

If you have questions, create a GitHub Issue in this repository.
