### PR TITLE
Allow standard exception to handle strings for JSON API responses

### DIFF
--- a/lib/PaymentRails/Exception/Standard.php
+++ b/lib/PaymentRails/Exception/Standard.php
@@ -4,26 +4,33 @@ namespace PaymentRails\Exception;
 use PaymentRails\Exception;
 
 /**
- * Raised when a standard error request is received
- *
- * @package    PaymentRails
- * @subpackage Exception
- */
+* Raised when a standard error request is received
+*
+* @package    PaymentRails
+* @subpackage Exception
+*/
 class Standard extends Exception
 {
-  protected $errorBody;
+	protected $errorBody;
 
-  public function __construct($errorBody)
-  {
-      $message = "";
-      foreach ($errorBody as $e) {
-        if (isset($e['field'])) {
-          $message = $message . $e['code'] . ": " . $e['message'] . " (field: '" . $e['field'] . "') \n";
-        } else {
-          $message = $message . $e['code'] . ": " . $e['message'] . "\n";
-        }
-      }
-      $this->message = $message;
-  }
+	/**
+	 * @var $errorBody string|array
+	 */
+	public function __construct($errorBody)
+	{
+		$message = '';
+		if (is_array($errorBody)) {
+			foreach($errorBody as $e) {
+				$message .= "{$e['code']}: {$e['message']}";
+				if (!empty($e['field'])) {
+					$message .= " (field: {$e['field']})";
+				}
+				$message .= "\n";
+			}
+		} elseif (is_string($errorBody)) {
+			$message = $errorBody;
+		}
+		$this->message = $message;
+	}
 }
 class_alias('PaymentRails\Exception\Standard', 'PaymentRails_Exception_Standard');

--- a/tests/Exception/StandardTest.php
+++ b/tests/Exception/StandardTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PaymentRails\Exception\Standard;
+
+class StandardTest extends TestCase
+{
+    public function testExceptionWithString()
+    {
+    	$this->expectException(Standard::class);
+    	$this->expectExceptionMessage('unknown');
+    	throw new Standard('unknown');
+    }
+
+    public function testExceptionWithArray()
+    {
+    	$errorBody = array(
+    		array(
+    			'code' => 404,
+    			'message' => 'not found',
+    			'field' => 'text'
+    		),
+    		array(
+    			'code' => 202,
+    			'message' => 'success'
+    		)
+    	);
+    	$this->expectException(Standard::class);
+    	$this->expectExceptionMessage(
+    		"404: not found (field: text)\n202: success\n"
+    	);
+    	throw new Standard($errorBody);
+    }
+}


### PR DESCRIPTION
<!--
We appreciate the effort for this pull request but before that please make sure you read the contribution guidelines, then fill out the blanks below.

Please format the PR title appropriately based on the type of change:
  <type>[!]: <description>
Where <type> is one of: docs, chore, feat, fix, test.
Add a '!' after the type for breaking changes (e.g. feat!: new breaking feature).

**All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.**

Please enter each Issue number you are resolving in your PR after one of the following words [Fixes, Closes, Resolves]. This will auto-link these issues and close them when this PR is merged!
e.g.
Fixes #1
Closes #2
-->

# Fix: Allow Standard Exception to handle strings #

Our company started using this SDK and we noticed that when an object is not found we received a blank exception message. Looking into the code I noticed that the Payment Rails API server is sending back JSON strings with the code and message. However, the Standard Exception does not take into account strings such as this case. The result is that the exception comes out blank. This PR fixes the exception to handle both strings and arrays.

### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
- [x] I have made a material change to the repo (functionality, testing, spelling, grammar)
- [x] I have titled the PR appropriately
- [x] I have updated my branch with the main branch
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation about the functionality in the appropriate .md file
- [x] I have added inline documentation to the code I modified

If you have questions, create a GitHub Issue in this repository.
