### PR TITLE
Add PHP 8.1 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ The Trolley PHP SDK provides integration access to the Trolley API.
 
 ## Requirements
 
-PHP version >= 5.4.0 is required.
+PHP version >= 7.0.0 is required.
 
 The following PHP extensions are required:
 
-curl
-json
-mbstring
-openssl
+`curl`
+`json`
+`mbstring`
+`openssl`
 
 ## Installation & Usage
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.0",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/lib/Trolley/Configuration.php
+++ b/lib/Trolley/Configuration.php
@@ -468,7 +468,7 @@ class Configuration
                 $ssl = true;
                 break;
            }
-           if (substr($this->_environment, 0, strlen('localhost')) === 'localhost') {
+           if (substr($this->_environment ?? '', 0, strlen('localhost')) === 'localhost') {
                $ssl = false;
            }
    

--- a/lib/Trolley/ResourceCollection.php
+++ b/lib/Trolley/ResourceCollection.php
@@ -56,6 +56,7 @@ class ResourceCollection implements Iterator
     /**
      * returns the current item when iterating with foreach
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->_items[$this->_index];
@@ -71,6 +72,7 @@ class ResourceCollection implements Iterator
         return $this->_items[0];
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return null;
@@ -79,6 +81,7 @@ class ResourceCollection implements Iterator
     /**
      * advances to the next item in the collection when iterating with foreach
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         ++$this->_index;
@@ -87,6 +90,7 @@ class ResourceCollection implements Iterator
     /**
      * rewinds the testIterateOverResults collection to the first item when iterating with foreach
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         $this->_index = 0;
@@ -95,6 +99,7 @@ class ResourceCollection implements Iterator
     /**
      * returns whether the current item is valid when iterating with foreach
      */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         if ($this->_index >= count($this->_items)) {


### PR DESCRIPTION
# Fixes
Without these fixes you will encounter PHP messages similar to these when using modern versions of PHP (8.1+):

```
substr(): Passing null to parameter #1 ($string) of type string is deprecated
file: trolley/core/lib/Trolley/Configuration.php
line: 471
```
and
```
Return type of Trolley\\ResourceCollection::current() should either be compatible with Iterator::current(): mixed, or the #[\\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
file: trolley/core/lib/Trolley/ResourceCollection.php
line: 59
```

...plus a few others related to the various other `Iterator` methods in `ResourceCollection.php`.

### Background
For a while we've been using an internally patched version of the older 2.x Trolley PHP SDK (the version previously using the `PaymentRails` namespace).

Given the recent library upgrades here and the new published versions, complete with new `Trolley` namespace, we decided to upgrade to the latest SDK here. In doing so we noticed these issues again, so I decided to go ahead and fork and create this PR!

### Notes

1. In the future you might consider adding return types within `ResourceCollection.php` as well and remove the `#[\ReturnTypeWillChange]` attributes which just suppress the notices. This may involve a little more work to ensure proper return types for each method.

2. The `substr()` deprecation fix we went with uses null coalescing and this requires PHP 7.0 or higher, so I've updated that dependency in `composer.json` and updated the readme.
    - That said, PHP 7.0 isn't supported any longer. You might also consider raising that minimum PHP version to 8.0 or higher to [mirror upstream PHP version support](https://www.php.net/supported-versions.php).

### Checklist

- [x] I acknowledge that all my contributions will be made under the project's license
